### PR TITLE
Take the two hands into account

### DIFF
--- a/src/me/mc_cloud/gapcooldown/Main.java
+++ b/src/me/mc_cloud/gapcooldown/Main.java
@@ -23,19 +23,14 @@ public class Main extends JavaPlugin {
 	 * Message config
 	 */
 	
-	public static final String CONFIG_HEADER = "GapCooldown version 2.0\n"
-			+ "";
+	private static final String CONFIG_HEADER = "GapCooldown version 2.0\n";
 	
-	public static Map<Material, Map<String, Long>> playerCooldowns = new HashMap<>();
-	public static Map<Material, Integer> itemCooldowns = new HashMap<>();
-	public static Map<PotionType, Integer> potionCooldowns = new HashMap<>();
-	public static Map<PotionType, Map<String, Long>> playerPotionCooldowns = new HashMap<>();
-	//public static Map<String, Long> enchantedGoldenAppleCooldowns = new HashMap<String, Long>();
-	//public static int ENCHANTED_GOLDEN_APPLE_COOLDOWN = 0;
-	//public static Map<String, Long> goldenAppleCooldowns = new HashMap<String, Long>();
-	//public static int GOLDEN_APPLE_COOLDOWN = 0;
+	public Map<Material, Map<String, Long>> playerCooldowns = new HashMap<>();
+	public Map<Material, Integer> itemCooldowns = new HashMap<>();
+	public Map<PotionType, Integer> potionCooldowns = new HashMap<>();
+	public Map<PotionType, Map<String, Long>> playerPotionCooldowns = new HashMap<>();
 	
-	public static final Material[] FOODS = {Material.ENCHANTED_GOLDEN_APPLE, Material.GOLDEN_APPLE, Material.APPLE, Material.BAKED_POTATO,
+	private final Material[] FOODS = {Material.ENCHANTED_GOLDEN_APPLE, Material.GOLDEN_APPLE, Material.APPLE, Material.BAKED_POTATO,
 			Material.BEETROOT, Material.BEETROOT_SOUP, Material.BREAD, Material.CARROT, Material.CHORUS_FRUIT, Material.COOKED_BEEF, Material.COOKED_CHICKEN, Material.COOKED_COD,
 			Material.COOKED_MUTTON, Material.COOKED_PORKCHOP, Material.COOKED_RABBIT, Material.COOKED_SALMON, Material.COOKIE, Material.DRIED_KELP,
 			Material.GLOW_BERRIES, Material.GOLDEN_CARROT, Material.HONEY_BOTTLE, Material.MELON_SLICE, Material.MUSHROOM_STEW, Material.POISONOUS_POTATO,
@@ -43,7 +38,7 @@ public class Main extends JavaPlugin {
 			Material.PORKCHOP, Material.RABBIT, Material.SALMON, Material.ROTTEN_FLESH, Material.SPIDER_EYE, Material.SUSPICIOUS_STEW, Material.SWEET_BERRIES,
 			Material.TROPICAL_FISH};
 	
-	public static final PotionType[] EFFECTS = PotionType.values();
+	private final PotionType[] EFFECTS = PotionType.values();
 	
 	
 	public static Main instance;
@@ -52,6 +47,22 @@ public class Main extends JavaPlugin {
 	@Override
 	public void onEnable() {
 		instance = this;
+		registerConfig();
+		populateMapConfig();
+
+		// Register listener
+		new StartEat(this);
+		new EndEat(this);
+		new OnDeath(this);
+		
+		new UpdateChecker(this, 101358).getVersion(version -> {
+			if (!this.getDescription().getVersion().equals(version)) {
+				getLogger().info("There is a new update available (" + version + ")! Go to https://www.spigotmc.org/resources/gap-cooldown.101358/ to download the new version.");
+			}
+		});
+	}
+
+	private void registerConfig() {
 		FileConfiguration config = getConfig();
 		
 		config.set("cooldownTime", null); // Remove old config
@@ -64,11 +75,12 @@ public class Main extends JavaPlugin {
 		config.options().copyDefaults(true);
 		config.options().header(CONFIG_HEADER);
 		saveConfig();
-		
-		
+	}
+
+	private void populateMapConfig() {
 		for (Material material : FOODS) {
 			int cooldown = config.getInt(material.toString().toLowerCase() + ".cooldown");
-			if (cooldown != 0) {
+			if (cooldown > 0) {
 				playerCooldowns.put(material, new HashMap<String, Long>());
 				itemCooldowns.put(material, cooldown);
 			}
@@ -76,21 +88,11 @@ public class Main extends JavaPlugin {
 		
 		for (PotionType potionType : EFFECTS) {
 			int cooldown = config.getInt("potion." + potionType.toString().toLowerCase() + ".cooldown");
-			if (cooldown != 0) {
+			if (cooldown > 0) {
 				potionCooldowns.put(potionType, cooldown);
 				playerPotionCooldowns.put(potionType, new HashMap<String, Long>());
 			}
 		}
-		
-		new StartEat(this);
-		new EndEat(this);
-		
-		new UpdateChecker(this, 101358).getVersion(version -> {
-            if (!this.getDescription().getVersion().equals(version)) {
-                getLogger().info("There is a new update available (" + version + ")! Go to https://www.spigotmc.org/resources/gap-cooldown.101358/ to download the new version.");
-            }
-        });
 	}
-
 
 }

--- a/src/me/mc_cloud/gapcooldown/listeners/EndEat.java
+++ b/src/me/mc_cloud/gapcooldown/listeners/EndEat.java
@@ -14,30 +14,31 @@ import me.mc_cloud.gapcooldown.utils.Utils;
 
 public class EndEat implements Listener {
 	
-	public Main plugin;
+	private Main plugin;
 	
 	public EndEat(Main plugin) {
 		this.plugin = plugin;
-		
 		Bukkit.getPluginManager().registerEvents(this, plugin);
 	}
 	
 	@EventHandler
 	public void onEat(PlayerItemConsumeEvent e) {
-		if (e.getPlayer().hasPermission("gapCooldown.ignore")) return;
-		
-		for (Material food : Main.itemCooldowns.keySet()) {
-			if (e.getItem().getType() == food) {
-				Main.playerCooldowns.get(food).put(e.getPlayer().getUniqueId().toString(), Utils.todayPlus(0, 0, 0, Main.itemCooldowns.get(food)));
-			}
+		Player player = e.getPlayer();
+		if (player.hasPermission("gapCooldown.ignore")) return;
+		String playerUuid = player.getUniqueId().toString();
+
+		Material eatedItem = e.getItem().getType();
+		if (plugin.itemCooldowns.keySet().contains(eatedItem)) {
+			Long nextEatAllowed = Utils.todayPlus(0, 0, 0, plugin.itemCooldowns.get(eatedItem));
+			plugin.playerCooldowns.get(food).put(playerUuid, nextEatAllowed));
 		}
-		
+
 		if (e.getItem().hasItemMeta() && e.getItem().getItemMeta() instanceof PotionMeta) {
-			for (PotionType type : Main.potionCooldowns.keySet()) {
-				PotionMeta meta = (PotionMeta) e.getItem().getItemMeta();
-				if (meta.getBasePotionData().getType() == type) {
-					Main.playerPotionCooldowns.get(type).put(e.getPlayer().getUniqueId().toString(), Utils.todayPlus(0, 0, 0, Main.potionCooldowns.get(type)));
-				}
+			PotionMeta potionMeta = (PotionMeta) e.getItem().getItemMeta();
+			PotionType potionType = potionMeta.getBasePotionType();
+			if (plugin.potionCooldowns.keySet().contains(potionType)) {
+				Long nextDrinkAllowed = Utils.todayPlus(0, 0, 0, plugin.potionCooldowns.get(potionType));
+				plugin.playerPotionCooldowns.get(potionType).put(playerUuid, nextDrinkAllowed));
 			}
 		}
 	}

--- a/src/me/mc_cloud/gapcooldown/listeners/OnDeath.java
+++ b/src/me/mc_cloud/gapcooldown/listeners/OnDeath.java
@@ -15,21 +15,17 @@ public class OnDeath implements Listener {
 	
 	public OnDeath(Main plugin) {
 		this.plugin = plugin;
-		
 		Bukkit.getPluginManager().registerEvents(this, plugin);
 	}
 	
 	@EventHandler
 	public void onEat(PlayerDeathEvent e) {
-		for (Material food : Main.itemCooldowns.keySet()) {
-			if (Main.playerCooldowns.get(food).containsKey(e.getEntity().getUniqueId().toString())) {
-				Main.playerCooldowns.get(food).remove(e.getEntity().getUniqueId().toString());
-			}
+		String entityUuid = e.getEntity().getUniqueId().toString();
+		for (Material food : plugin.itemCooldowns.keySet()) {
+			plugin.playerCooldowns.get(food).remove(entityUuid);
 		}
-		for (PotionType type : Main.potionCooldowns.keySet()) {
-			if (Main.playerPotionCooldowns.get(type).containsKey(e.getEntity().getUniqueId().toString())) {
-				Main.playerPotionCooldowns.get(type).remove(e.getEntity().getUniqueId().toString());
-			}
+		for (PotionType type : plugin.potionCooldowns.keySet()) {
+			plugin.playerPotionCooldowns.get(type).remove(entityUuid);
 		}
 	}
 }

--- a/src/me/mc_cloud/gapcooldown/listeners/StartEat.java
+++ b/src/me/mc_cloud/gapcooldown/listeners/StartEat.java
@@ -9,6 +9,9 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.meta.PotionMeta;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.potion.PotionType;
+import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.potion.PotionType;
 
 import me.mc_cloud.gapcooldown.Main;
@@ -20,43 +23,69 @@ import net.md_5.bungee.api.chat.TextComponent;
 
 public class StartEat implements Listener {
 	
-	public Main plugin;
+	private Main plugin;
 	
 	public StartEat(Main plugin) {
 		this.plugin = plugin;
-		
 		Bukkit.getPluginManager().registerEvents(this, plugin);
 	}
 	
-	@SuppressWarnings("deprecation")
 	@EventHandler
 	public void onEat(PlayerInteractEvent e) {
 		if (e.getPlayer().hasPermission("gapCooldown.ignore")) return;
 		if (e.getAction() == Action.RIGHT_CLICK_AIR || e.getAction() == Action.RIGHT_CLICK_BLOCK) {
-			
-			for (Material food : Main.itemCooldowns.keySet()) {
-				if (e.getPlayer().getItemInHand().getType() == food) {
-					if (!Main.playerCooldowns.get(food).containsKey(e.getPlayer().getUniqueId().toString())) return;
-					if (Main.playerCooldowns.get(food).get(e.getPlayer().getUniqueId().toString()) > new Date().getTime()) {
-						e.setCancelled(true);
-						if (Main.instance.getConfig().getBoolean("wait-messages.chat")) e.getPlayer().sendMessage(ChatColor.RED + "That item is on cooldown. Try again in " + Utils.secsUntil(Main.playerCooldowns.get(food).get(e.getPlayer().getUniqueId().toString())) + "s");
-						if (Main.instance.getConfig().getBoolean("wait-messages.action-bar")) e.getPlayer().spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(ChatColor.RED + "That item is on cooldown. Try again in " + Utils.secsUntil(Main.playerCooldowns.get(food).get(e.getPlayer().getUniqueId().toString())) + "s"));
-					}
-				}
+			PlayerInventory playerInventory = e.getPlayer().getInventory();
+			Material mainHandItem = playerInventory.getItemInMainHand();
+			Material offHandItem = playerInventory.getItemInOffHand();
+			if (areCooldownForThisFood(mainHandItem)) {
+				cancelEventIfNeeded(e, getPlayerCooldown(plugin.playerCooldowns.get(mainHandItem), e.getPlayer())); 
 			}
-			
-			if (e.getPlayer().getItemInHand().getType() == Material.POTION) {
-				PotionMeta meta = (PotionMeta) e.getPlayer().getItemInHand().getItemMeta();
-				for (PotionType type : Main.potionCooldowns.keySet()) {
-					if (meta.getBasePotionData().getType() == type) {
-						if (!Main.playerPotionCooldowns.get(type).containsKey(e.getPlayer().getUniqueId().toString())) return;
-						if (Main.playerPotionCooldowns.get(type).get(e.getPlayer().getUniqueId().toString()) > new Date().getTime()) {
-							e.setCancelled(true);
-							if (Main.instance.getConfig().getBoolean("wait-messages.chat")) e.getPlayer().sendMessage(ChatColor.RED + "That item is on cooldown. Try again in " + Utils.secsUntil(Main.playerPotionCooldowns.get(type).get(e.getPlayer().getUniqueId().toString())) + "s");
-							if (Main.instance.getConfig().getBoolean("wait-messages.action-bar")) e.getPlayer().spigot().sendMessage(ChatMessageType.ACTION_BAR, TextComponent.fromLegacyText(ChatColor.RED + "That item is on cooldown. Try again in " + Utils.secsUntil(Main.playerPotionCooldowns.get(type).get(e.getPlayer().getUniqueId().toString())) + "s"));
-						}
-					}
-				}
+			if (areCooldownForThisFood(offHandItem)) {
+				cancelEventIfNeeded(e, getPlayerCooldown(plugin.playerCooldowns.get(offHandItem), e.getPlayer())); 
+			}
+			if (areCooldownForThisPotion(mainHandItem)) {
+				cancelEventIfNeeded(e, getPlayerCooldown(plugin.playerPotionCooldowns.get(mainHandItem), e.getPlayer());
+			}
+			if (areCooldownForThisPotion(offHandItem)) {
+				cancelEventIfNeeded(e, getPlayerCooldown(plugin.playerPotionCooldowns.get(mainHandItem), e.getPlayer());
+			}
+		}
+	}
+
+	private boolean areCooldownForThisFood(ItemStack itemInHand) {
+		return plugin.itemCooldowns.keySet().contains(itemInHand.getType());
+	}
+
+	private boolean areCooldownForThisPotion(ItemStack itemInHand) {
+		if (itemInHand.getType().equals(Material.POTION)) {
+			PotionMeta potionMeta = (PotionMeta) itemInHand.getItemMeta();
+			return plugin.playerPotionCooldowns.keySet().contains(potionMeta.getBasePotionType());
+		}
+		return false;
+	}
+	
+	private Long getPlayerCooldown(Map<String, Long> playerItemCooldowns, Player player) {
+		String playerUuid = player.getUniqueId().toString();
+		if (playerItemCooldowns.containsKey(playerUuid)) {
+			Long lastEat = playerItemCooldowns.get(playerUuid);
+			if (lastEat > new Date().getTime()) {
+				return lastEat - new Date().getTime();
+			}
+		}
+		return 0l;
+	}
+
+	private void cancelEventIfNeeded(PlayerInteractEvent event, Long cooldown) {
+		if (cooldown > 0) {
+			event.setCancelled(true);
+			FileConfiguration config = plugin.getConfig();
+			int cooldownSec = (int) (cooldown / 1000);
+			if (config.getBoolean("wait-messages.chat")) {
+				event.getPlayer().sendMessage(ChatColor.RED + "That item is on cooldown. Try again in " + cooldownSec + "s");
+			}
+			if (config.getBoolean("wait-messages.action-bar")) {
+				event.getPlayer().spigot().sendMessage(ChatMessageType.ACTION_BAR,
+					TextComponent.fromLegacyText(ChatColor.RED + "That item is on cooldown. Try again in " + cooldownSec + "s"));	
 			}
 		}
 	}


### PR DESCRIPTION
Hello,

Thank you for this plugin. One user of the [MinecraftFr discord](https://discord.com/invite/minecraftfr) has trouble with your plugin. I check the source code and see that it doesn't consider the fact that now (since 1.9), the user has two hands...
I also see that you never use "contains" which is more efficient than comparing one element on a list.

So, I propose this Pull Request where:
- I use contains in place of loop and `==`
- I changed some `public` into `private` (it's a good practice to limit accessibility of methods/attributes)
- I access to resource using a plugin instance (in place of Main and `static`)

> :warning: Please note that I don't have a clean Java environment for the moment. Thus, I develop all of this directly on GitHub!  It means that no IDE checks the import or checks that the syntax is correct.
Please take time to review and test (build, for example) before merging (or at least before publishing a new version).

:speech_balloon: Feel free to ask questions on why I did something in the code.


